### PR TITLE
Strip binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apk --update add mysql-client mariadb-client-libs libpq sqlite-libs libstdc+
     cd /tmp/pdns-$POWERDNS_VERSION && \
     ./configure --prefix="" --exec-prefix=/usr --sysconfdir=/etc/pdns \
       --with-modules="bind gmysql gpgsql gsqlite3" --without-lua && \
-    make && make install && cd / && \
+    make && make install-strip && cd / && \
     mkdir -p /etc/pdns/conf.d && \
     addgroup -S pdns 2>/dev/null && \
     adduser -S -D -H -h /var/empty -s /bin/false -G pdns -g pdns pdns 2>/dev/null && \


### PR DESCRIPTION
Use install-strip target to reduce the overall size of the image (180 MiB-> 60MiB )

Signed-off-by: Mathias Kaufmann <me@stei.gr>