### PR TITLE
Clarify Initialisation process

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,8 @@ if $MYSQL_AUTOCONF ; then
   # init database if necessary
   echo "CREATE DATABASE IF NOT EXISTS $MYSQL_DB;" | $MYSQLCMD
   MYSQLCMD="$MYSQLCMD $MYSQL_DB"
-
+  
+  # -le flag is used to prevent usage of incompletely applied schema
   if [ "$(echo "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = \"$MYSQL_DB\";" | $MYSQLCMD)" -le 1 ]; then
     echo Initializing Database
     cat /etc/pdns/schema.sql | $MYSQLCMD


### PR DESCRIPTION
Can be useful to drop a line about why we have `-le` flag. It is clear after debug that it is to do with incomplete schema rollout. But one small comment could save next person couple of hours ;)