### PR TITLE
Version number bump to 4.1.10 to fix a security issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 FROM alpine:3.7
 MAINTAINER Christoph Wiechert <wio@psitrax.de>
 
-ENV REFRESHED_AT="2019-03-18" \
-    POWERDNS_VERSION=4.1.7 \
+ENV REFRESHED_AT="2019-06-21" \
+    POWERDNS_VERSION=4.1.10 \
     MYSQL_AUTOCONF=true \
     MYSQL_HOST="mysql" \
     MYSQL_PORT="3306" \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Supported tags
 
-* Exact: i.e. `4.1.7`: PowerDNS Version 4.1.7
+* Exact: i.e. `4.1.10`: PowerDNS Version 4.1.10
 * `4.0`: PowerDNS Version 4.0.x, latest image build
 * `4`: PowerDNS Version 4.x.x, latest image build
 


### PR DESCRIPTION
The PowerDNS team released a [security advisory today](https://doc.powerdns.com/authoritative/security-advisories/powerdns-advisory-2019-04.html) stating that every PowerDNS users need to update to PowerDNS 4.1.10.