### PR TITLE
Add docker secrets support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@ MAINTAINER Christoph Wiechert <wio@psitrax.de>
 
 ENV REFRESHED_AT="2019-10-10" \
     POWERDNS_VERSION=4.2.0 \
-    MYSQL_AUTOCONF=true \
-    MYSQL_HOST="mysql" \
-    MYSQL_PORT="3306" \
-    MYSQL_USER="root" \
-    MYSQL_PASS="root" \
-    MYSQL_DB="pdns"
+    MYSQL_DEFAULT_AUTOCONF=true \
+    MYSQL_DEFAULT_HOST="mysql" \
+    MYSQL_DEFAULT_PORT="3306" \
+    MYSQL_DEFAULT_USER="root" \
+    MYSQL_DEFAULT_PASS="root" \
+    MYSQL_DEFAULT_DB="pdns"
 
-RUN apk --update add libpq sqlite-libs libstdc++ libgcc mariadb-client mariadb-connector-c && \
+RUN apk --update add bash libpq sqlite-libs libstdc++ libgcc mariadb-client mariadb-connector-c && \
     apk add --virtual build-deps \
       g++ make mariadb-dev postgresql-dev sqlite-dev curl boost-dev mariadb-connector-c-dev && \
     curl -sSL https://downloads.powerdns.com/releases/pdns-$POWERDNS_VERSION.tar.bz2 | tar xj -C /tmp && \

--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ $ docker run --name pdns \
   * `MYSQL_PASS=root`
   * `MYSQL_DB=pdns`
   * `MYSQL_DNSSEC=no`
+* To support docker secrets, use same variables as above with suffix `_FILE`.
 * Want to disable mysql initialization? Use `MYSQL_AUTOCONF=false`
 * DNSSEC is disabled by default, to enable use `MYSQL_DNSSEC=yes`
 * Want to use own config files? Mount a Volume to `/etc/pdns/conf.d` or simply overwrite `/etc/pdns/pdns.conf`
 
 **PowerDNS Configuration:**
 
-Append the PowerDNS setting to the command as shown in the example above.  
+Append the PowerDNS setting to the command as shown in the example above.
 See `docker run --rm psitrax/powerdns --help`
 
 


### PR DESCRIPTION
Can you add this request, it enables support for docker secrets. This gives a more secure option of storing credentials and pass them to containers.