### PR TITLE
docs: Fix supported tags and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/psitrax/powerdns.svg)](https://hub.docker.com/r/psitrax/powerdns/)
 [![Docker Automated buil](https://img.shields.io/docker/automated/psitrax/powerdns.svg)](https://hub.docker.com/r/psitrax/powerdns/)
 
-* Small Alpine based Image
-* MySQL (default), Postgres, SQLite and Bind backend included
-* DNSSEC support optional
-* Automatic MySQL database initialization
-* Latest PowerDNS version (if not pls file an issue)
-* Guardian process enabled
-* Graceful shutdown using pdns_control
+-   Small Alpine based Image
+-   MySQL (default), Postgres, SQLite and Bind backend included
+-   DNSSEC support optional
+-   Automatic MySQL database initialization
+-   Latest PowerDNS version (if not pls file an issue)
+-   Guardian process enabled
+-   Graceful shutdown using pdns_control
 
 ## Supported tags
 
-* Exact: i.e. `4.3.0`: PowerDNS Version 4.3.0
-* `4.0`: PowerDNS Version 4.0.x, latest image build
-* `4`: PowerDNS Version 4.x.x, latest image build
+-   Exact: i.e. `4.3.0`: PowerDNS Version 4.3.0
+-   `4.3`: PowerDNS Version 4.3.x, latest image build
+-   `4`: PowerDNS Version 4.x.x, latest image build
 
 ## Usage
 
@@ -44,33 +44,30 @@ $ docker run --name pdns \
 
 **Environment Configuration:**
 
-* MySQL connection settings
-  * `MYSQL_HOST=mysql`
-  * `MYSQL_USER=root`
-  * `MYSQL_PASS=root`
-  * `MYSQL_DB=pdns`
-  * `MYSQL_DNSSEC=no`
-* To support docker secrets, use same variables as above with suffix `_FILE`.
-* Want to disable mysql initialization? Use `MYSQL_AUTOCONF=false`
-* DNSSEC is disabled by default, to enable use `MYSQL_DNSSEC=yes`
-* Want to use own config files? Mount a Volume to `/etc/pdns/conf.d` or simply overwrite `/etc/pdns/pdns.conf`
+-   MySQL connection settings
+    -   `MYSQL_HOST=mysql`
+    -   `MYSQL_USER=root`
+    -   `MYSQL_PASS=root`
+    -   `MYSQL_DB=pdns`
+    -   `MYSQL_DNSSEC=no`
+-   To support docker secrets, use same variables as above with suffix `_FILE`.
+-   Want to disable mysql initialization? Use `MYSQL_AUTOCONF=false`
+-   DNSSEC is disabled by default, to enable use `MYSQL_DNSSEC=yes`
+-   Want to use own config files? Mount a Volume to `/etc/pdns/conf.d` or simply overwrite `/etc/pdns/pdns.conf`
 
 **PowerDNS Configuration:**
 
 Append the PowerDNS setting to the command as shown in the example above.
 See `docker run --rm psitrax/powerdns --help`
 
-
 ## License
 
 [GNU General Public License v2.0](https://github.com/PowerDNS/pdns/blob/master/COPYING) applyies to PowerDNS and all files in this repository.
 
-
 ## Maintainer
 
-* Christoph Wiechert <wio@psitrax.de>
+-   Christoph Wiechert [wio@psitrax.de](mailto:wio@psitrax.de)
 
 ### Credits
 
-* Mathias Kaufmann <me@stei.gr>: Reduced image size
-
+-   Mathias Kaufmann [me@stei.gr](mailto:me@stei.gr): Reduced image size

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ docker run --name pdns \
 
 ## Configuration
 
-**Environment Configuration:**
+### Environment Configuration
 
 -   MySQL connection settings
     -   `MYSQL_HOST=mysql`
@@ -55,7 +55,7 @@ $ docker run --name pdns \
 -   DNSSEC is disabled by default, to enable use `MYSQL_DNSSEC=yes`
 -   Want to use own config files? Mount a Volume to `/etc/pdns/conf.d` or simply overwrite `/etc/pdns/pdns.conf`
 
-**PowerDNS Configuration:**
+### PowerDNS Configuration
 
 Append the PowerDNS setting to the command as shown in the example above.
 See `docker run --rm psitrax/powerdns --help`


### PR DESCRIPTION
Fix the supported tags (4.0 to 4.3) and improve general README format using [remark-stringify](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
