### PR TITLE
Copy libboost_program_options.so to use pdnsutil command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ RUN apk --update add bash libpq sqlite-libs libstdc++ libgcc mariadb-client mari
     mkdir -p /etc/pdns/conf.d && \
     addgroup -S pdns 2>/dev/null && \
     adduser -S -D -H -h /var/empty -s /bin/false -G pdns -g pdns pdns 2>/dev/null && \
+    cp /usr/lib/libboost_program_options.so* /tmp && \
     apk del --purge build-deps && \
+    mv /tmp/lib* /usr/lib/ && \
     rm -rf /tmp/pdns-$POWERDNS_VERSION /var/cache/apk/*
 
 ADD schema.sql pdns.conf /etc/pdns/


### PR DESCRIPTION
`psitrax/powerdns:v4.4.1` cannot execute `pdnsutil` command because `libboost_program_options.so.1.72.0` is missing.

```bash
$ docker run --rm -it psitrax/powerdns:v4.4.1 /bin/bash
bash-5.1# pdnsutil
Error loading shared library libboost_program_options.so.1.72.0: No such file or directory (needed by /usr/bin/pdnsutil)
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options29options_description_easy_initclEPKcPKNS0_14value_semanticE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_optionslsERSoRKNS0_19options_descriptionE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options6detail7cmdline3runEv: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options13variables_mapC1Ev: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options6notifyERNS0_13variables_mapE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options20invalid_option_valueC1ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options6detail7cmdlineC2ERKSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options6detail7cmdline23set_options_descriptionERKNS0_19options_descriptionE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options11to_internalERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options30positional_options_description3addEPKci: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22abstract_variables_mapixERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options19options_description11add_optionsEv: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options6detail7cmdline27get_canonical_option_prefixEv: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options30positional_options_descriptionC1Ev: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options8validateERNS_3anyERKSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS9_EEPS9_i: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options19options_descriptionC1ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEjj: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options6detail7cmdline22set_positional_optionsERKNS0_30positional_options_descriptionE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options5storeERKNS0_20basic_parsed_optionsIcEERNS0_13variables_mapEb: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options29options_description_easy_initclEPKcS3_: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options29options_description_easy_initclEPKcPKNS0_14value_semanticES3_: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22error_with_option_name4whatEv: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22error_with_option_name4whatEv: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22error_with_option_name4whatEv: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22error_with_option_name4whatEv: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22error_with_option_name4whatEv: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22error_with_option_name4whatEv: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22error_with_option_name23substitute_placeholdersERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22error_with_option_name23substitute_placeholdersERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22error_with_option_name23substitute_placeholdersERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22error_with_option_name23substitute_placeholdersERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22error_with_option_name23substitute_placeholdersERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options22error_with_option_name23substitute_placeholdersERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZTIN5boost15program_options22error_with_option_nameE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZTIN5boost15program_options29value_semantic_codecvt_helperIcEE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZTIN5boost15program_options29value_semantic_codecvt_helperIcEE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options29value_semantic_codecvt_helperIcE5parseERNS_3anyERKSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEb: symbol not found
Error relocating /usr/bin/pdnsutil: _ZNK5boost15program_options29value_semantic_codecvt_helperIcE5parseERNS_3anyERKSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaISB_EEb: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options19options_description21m_default_line_lengthE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZTVN5boost15program_options22error_with_option_nameE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZTVN5boost15program_options13variables_mapE: symbol not found
Error relocating /usr/bin/pdnsutil: _ZN5boost15program_options3argB5cxx11E: symbol not found

bash-5.1# ls -ls /usr/bin/libboost_program_options*
ls: /usr/bin/libboost_program_options*: No such file or directory
```

I fixed it with reference to this: https://github.com/psi-4ward/docker-powerdns/commit/5adc11e777f6f6ca3d32ba43d0fda27132b56a47#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557