### PR TITLE
Install Cpp boost library as dependency for pdnsutil

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk --update add bash libpq sqlite-libs libstdc++ libgcc mariadb-client mari
     adduser -S -D -H -h /var/empty -s /bin/false -G pdns -g pdns pdns 2>/dev/null && \
     cp /usr/lib/libboost_program_options.so* /tmp && \
     apk del --purge build-deps && \
+    apk add boost-libs && \
     mv /tmp/lib* /usr/lib/ && \
     rm -rf /tmp/pdns-$POWERDNS_VERSION /var/cache/apk/*
 


### PR DESCRIPTION
* solves #66
* boost library is an requirement for pdnsutil but
  has previously been removed from the Docker image
  as part of build dependencies for PDNS.